### PR TITLE
feat: support notion does_not_contain filter operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Example response:
 * equals
 * does_not_equal
 * contains
+* does_not_contain
 * starts_with
 * ends_with
 * is_empty

--- a/database/filtertree-parser/mongo_filter_tree_parser.go
+++ b/database/filtertree-parser/mongo_filter_tree_parser.go
@@ -1,9 +1,12 @@
 package filtertreeparser
 
 import (
+	"regexp"
+
 	"github.com/marc7806/notion-cache/notion"
 	"github.com/marc7806/notion-cache/utils"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type MongoDbParser struct{}
@@ -37,6 +40,10 @@ func mapOperationToMongoDbRepresentation(operation *notion.FilterOperation) inte
 	} else if operation.Condition == notion.Contains {
 		return bson.M{
 			"$regex": operation.Value,
+		}
+	} else if operation.Condition == notion.DoesNotContain {
+		return bson.M{
+			"$not": primitive.Regex{Pattern: regexp.QuoteMeta(operation.Value)},
 		}
 	} else if operation.Condition == notion.StartsWith {
 		return bson.M{

--- a/database/filtertree-parser/mongo_filter_tree_parser_test.go
+++ b/database/filtertree-parser/mongo_filter_tree_parser_test.go
@@ -43,3 +43,35 @@ func TestCreateNestedFilterTree(t *testing.T) {
 		t.Errorf("Wrong property value. Expected '%s' but was '%s'", "My custom value", prop1["properties.Test Property 1.value"].(primitive.M)["$eq"])
 	}
 }
+
+func TestDoesNotContainFilter(t *testing.T) {
+	var inputData map[string]interface{}
+	filterQueryJson := []byte(`
+	{
+        "property": "Test Property 1",
+        "text": {
+            "does_not_contain": "vorläuf. Freigabe Live-CC"
+        }
+    }
+	`)
+	err := json.Unmarshal(filterQueryJson, &inputData)
+	if err != nil {
+		t.Error("Error while unmarshalling input json string")
+	}
+	filterTree := notion.CreateFilterTree(inputData)
+	mongoQuery := *ParseFilterTree(filterTree)
+
+	condition, ok := mongoQuery["properties.Test Property 1.value"].(primitive.M)
+	if !ok {
+		t.Fatalf("Missing condition for property. Query was '%s'", mongoQuery)
+	}
+	regex, ok := condition["$not"].(primitive.Regex)
+	if !ok {
+		t.Fatalf("Wrong condition. Expected '$not' with regex value but was '%s'", condition)
+	}
+	// the dot is a regex metacharacter and has to be escaped to match literally
+	expectedPattern := `vorläuf\. Freigabe Live-CC`
+	if regex.Pattern != expectedPattern {
+		t.Errorf("Wrong regex pattern. Expected '%s' but was '%s'", expectedPattern, regex.Pattern)
+	}
+}


### PR DESCRIPTION
Map the does_not_contain condition to a MongoDB `$not` with a regex value object. The `$regex` string operator is only valid directly under a field, so a primitive.Regex is used instead, which also keeps the query compatible with MongoDB versions before 4.0.7. The value is escaped with regexp.QuoteMeta so metacharacters match literally.